### PR TITLE
Change douane-configurator to use https for gtktwitterbox submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "douane/gtktwitterbox"]
 	path = douane/gtktwitterbox
-	url = git@github.com:zedtux/gtktwitterbox.git
+	url = https://github.com/zedtux/gtktwitterbox.git


### PR DESCRIPTION
This makes it easier for people without github accounts to sync the
sources for Douane, and build it straight out of the box (for example,
to enable integration with a packager that builds it from source)
